### PR TITLE
Allow separate policy attachment to role to enable reading budgets

### DIFF
--- a/nagios_role.tf
+++ b/nagios_role.tf
@@ -26,3 +26,9 @@ resource "aws_iam_role_policy_attachment" "nagios_cloudwatch_read" {
   role       = aws_iam_role.nagios_iam_role[0].name
 }
 
+resource "aws_iam_role_policy_attachment" "nagios_cloudwatch_budget_read" {
+  count = var.create_nagios_budget_role ? 1 : 0
+
+  policy_arn = "arn:aws:iam::aws:policy/AWSBudgetsReadOnlyAccess"
+  role       = aws_iam_role.nagios_iam_role[0].name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -127,6 +127,11 @@ variable "create_nagios_role" {
   default     = false
 }
 
+variable "create_nagios_budget_role" {
+  description = "Whether nagios budget role has to be created"
+  default     = false
+}
+
 # Datadog
 
 variable "create_datadog_role" {


### PR DESCRIPTION
This separate policy attachment is introduced as a  way for nagios to read budgets.
By utilizing a separate role we can decide wether to use it for specific accounts instead of just everywhere.

This way we can keep our accounts as clean as possible _(permission wise)_ whilst being able to read the budgets from the accounts that we need to read from.


