### PR TITLE
Feature/aws budget reader role

### DIFF
--- a/nagios_role.tf
+++ b/nagios_role.tf
@@ -27,7 +27,7 @@ resource "aws_iam_role_policy_attachment" "nagios_cloudwatch_read" {
 }
 
 resource "aws_iam_role_policy_attachment" "nagios_cloudwatch_budget_read" {
-  count = var.create_nagios_budget_role ? 1 : 0
+  count = var.add_budget_policy_attachment ? 1 : 0
 
   policy_arn = "arn:aws:iam::aws:policy/AWSBudgetsReadOnlyAccess"
   role       = aws_iam_role.nagios_iam_role[count.index].name

--- a/nagios_role.tf
+++ b/nagios_role.tf
@@ -23,12 +23,12 @@ resource "aws_iam_role_policy_attachment" "nagios_cloudwatch_read" {
   count = var.create_nagios_role ? 1 : 0
 
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
-  role       = aws_iam_role.nagios_iam_role[0].name
+  role       = aws_iam_role.nagios_iam_role[count.index].name
 }
 
 resource "aws_iam_role_policy_attachment" "nagios_cloudwatch_budget_read" {
   count = var.create_nagios_budget_role ? 1 : 0
 
   policy_arn = "arn:aws:iam::aws:policy/AWSBudgetsReadOnlyAccess"
-  role       = aws_iam_role.nagios_iam_role[0].name
+  role       = aws_iam_role.nagios_iam_role[count.index].name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -127,8 +127,8 @@ variable "create_nagios_role" {
   default     = false
 }
 
-variable "create_nagios_budget_role" {
-  description = "Whether nagios budget role has to be created"
+variable "add_budget_policy_attachment" {
+  description = "Whether to add an additional policy attachment that adds the 'AWSBudgetsReadOnlyAccess' policy to the nagios role"
   default     = false
 }
 


### PR DESCRIPTION
This pr contains the following fixes:

**Make index flexible to support > 1 attachment**
  The old index was set to 0,
  this made it so that you could only have 1 policy attachment.
  
**Refactored the variable name to reflect function**
  The old variable name and description didn't match it's function.
  This should make working with these variables easier to understand.