### PR TITLE
Add optional SLA reporter role

### DIFF
--- a/sla_reporter_role.tf
+++ b/sla_reporter_role.tf
@@ -1,0 +1,27 @@
+resource "aws_iam_role" "sla_reporter" {
+  count = var.create_sla_reporter_role ? 1 : 0
+
+  name               = "SLAReporter"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "sla_reporter" {
+  count = var.create_sla_reporter_role ? 1 : 0
+
+  role       = aws_iam_role.sla_reporter[count.index].name
+  policy_arn = aws_iam_policy.sla_reporter[count.index].arn
+}
+
+resource "aws_iam_policy" "sla_reporter" {
+  count = var.create_sla_reporter_role ? 1 : 0
+
+  name   = "SLAReporter"
+  policy = data.aws_iam_policy_document.sla_reporter.json
+}
+
+data "aws_iam_policy_document" "sla_reporter" {
+  statement {
+    resources = ["*"]
+    actions   = ["ce:GetCostAndUsage"]
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -138,3 +138,10 @@ variable "create_datadog_role" {
   description = "Whether datadog role has to be created"
   default     = false
 }
+
+# SLA Report
+
+variable "create_sla_reporter_role" {
+  description = "Create role used by SLA report generator"
+  default     = false
+}


### PR DESCRIPTION
The first use of this new role will be getting the total costs per month. This will be used in the SLA reporter application to show the total costs per account. This might get other responsibilities in the future, for instance for reporting CloudWatch statistics.