### PR TITLE
Feature/update module - adding OIDC assume role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,16 @@ data "aws_iam_policy_document" "assume_role" {
       identifiers = var.trusted_role_arns
     }
   }
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.trusted_roles_ci_cd
+    }
+  }
 }
 
 data "aws_iam_policy_document" "assume_role_with_mfa" {

--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,16 @@ data "aws_iam_policy_document" "assume_role_with_mfa" {
       values   = [var.mfa_age]
     }
   }
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.trusted_roles_ci_cd
+    }
+  }
 }
 
 # Admin

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "trusted_role_arns" {
   default     = []
 }
 
+variable "trusted_roles_ci_cd" {
+  description = "ARNs of AWS entities who can assume these roles for CI/CD"
+  default     = []
+}
+
+
 variable "mfa_age" {
   description = "Max age of valid MFA (in seconds) for roles which require MFA"
   default     = 86400


### PR DESCRIPTION
## What

**Updating the Module by adding assume role part for OIDC provider so OIDC can assume the "Admin" role in Kabisa-iam account.**
## Why

**This update is to create a Bypass for the OIDC to be able to assume the "Admin" role since there is a pre-condition that MFA has to be enabled to be able to assume the "Admin" role.** 
## Code Review

Please consider the following checklist when reviewing this Pull Request.  
More background and details [here](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md).

* [ ] Does the code **actually solve** the problem it was meant to solve?
* [ ] Is the code covered by **unit tests**? **Integration tests**?
* [ ] Does anything here need **documentation**? (Focus on *why*, not *what.*)
* [ ] Does any of this code deal with **privacy sensitive information** or affects **security**? Ask an additional reviewer.
* [ ] Is the code easy to **understand** and **change** in the future?
* [ ] Is the same code or concept **duplicated**? Find a balance between DRYness and readability.
* [ ] Does the code reasonably adhere to the Kabisa [**coding standards**](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md)?
* [ ] Be kind.
